### PR TITLE
[CI] Use gh cli for dev releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,37 +2,38 @@ name: Build And Release GooseMod Dev
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
     paths:
-    - 'src/**'
-    - 'building/**'
-    - 'CHANGELOG.md'
+      - 'src/**'
+      - 'building/**'
+      - 'CHANGELOG.md'
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
-    - name: Setup Node.js v15.x
-      uses: actions/setup-node@v2
-      with:
-        node-version: 15.x
+      - name: Setup Node.js v15.x
+        uses: actions/setup-node@v2
+        with:
+          node-version: 15.x
 
-    - name: Install NPM dependencies
-      run: npm ci
-      
-    - name: Build GooseMod
-      run: npm run build
+      - name: Install NPM dependencies
+        run: npm ci
 
-    - uses: "marvinpinto/action-automatic-releases@latest"
-      with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "dev"
-        prerelease: true
-        title: "GooseMod Dev"
-        files: |
-          dist/index.js
+      - name: Build GooseMod
+        run: npm run build
+
+      - name: Create dev release
+        run: |
+          gh release delete ${{ env.VERSION }} -y
+          gh release create ${{ env.VERSION }} -p -t "${{ env.NAME }}" ${{ env.FILES }}
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          VERSION: 'dev'
+          NAME: 'GooseMod Dev'
+          FILES: dist/index.js


### PR DESCRIPTION
This PR removes the use of the release Action which, for unknown reasons, duplicates the latest commit message on webhooks before creating a release.
The issue is solved by simply using GitHub's CLI for creating a release.