### PR TITLE
Open Link button in the Repos Modal

### DIFF
--- a/building/i18n/translations/en-US.json
+++ b/building/i18n/translations/en-US.json
@@ -9,6 +9,7 @@
     "install": "Install",
     "add": "Add",
     "remove": "Remove",
+    "openLink": "Open Link",
 
     "refresh": "Refresh",
 

--- a/src/ui/settings/baseItems.js
+++ b/src/ui/settings/baseItems.js
@@ -189,7 +189,7 @@ export default (goosemodScope, gmSettings, Items) => {
       buttonText: '#settings.items.start_tour.button#',
 
       onclick: async () => {
-        document.querySelector('.closeButton-1tv5uR').click(); // Close settings
+        goosemodScope.settings.closeSettings();
 
         goosemodScope.ootb.start();
       }

--- a/src/ui/settings/home/repos.js
+++ b/src/ui/settings/home/repos.js
@@ -21,6 +21,21 @@ export default async () => {
       return React.createElement('div', {},
         React.createElement(Button, {
           style: {
+            width: '100px',
+
+            position: 'absolute',
+            right: '108px',
+            marginTop: '33px'
+          },
+
+          color: ButtonClasses['colorPrimary'],
+          size: ButtonClasses['sizeSmall'],
+
+          onClick: this.props.buttonOpenLink
+        }, '#terms.openLink#'),
+
+        React.createElement(Button, {
+          style: {
             width: '92px',
             
             position: 'absolute',
@@ -161,6 +176,10 @@ export default async () => {
           repo.enabled = e;
 
           updateAfterChange();
+        },
+
+        buttonOpenLink: () => {
+          window.open(repo.url);
         },
 
         buttonOnClick: async () => {


### PR DESCRIPTION
Adds a "Open Link" button in the Repos Modal which when clicked, opens the URL of the repo.

![image](https://user-images.githubusercontent.com/48562304/181916619-57a346cd-bf12-4f9d-baec-43bf5998b2e3.png)
