### PR TITLE
Open Link button in the Repos Modal

### DIFF
--- a/bootstrap/index.js
+++ b/bootstrap/index.js
@@ -21,8 +21,8 @@ const init = async () => {
   
   console.log('[GooseMod Bootstrap]', 'Found locale', locale);
   
-  // eval(await (await fetch(`http://localhost:1234/goosemod.${locale}.js`)).text());
-  eval(await (await fetch(`https://raw.githubusercontent.com/GooseMod/GooseMod/dist-dev/goosemod.${locale}.js?_<buildtime>`, { cache: 'force-cache' })).text());
+  eval(await (await fetch(`http://localhost:1234/goosemod.${locale}.js`)).text());
+  // eval(await (await fetch(`https://raw.githubusercontent.com/GooseMod/GooseMod/dist-dev/goosemod.${locale}.js?_<buildtime>`, { cache: 'force-cache' })).text());
 };
 
 init();

--- a/bootstrap/index.js
+++ b/bootstrap/index.js
@@ -21,8 +21,8 @@ const init = async () => {
   
   console.log('[GooseMod Bootstrap]', 'Found locale', locale);
   
-  eval(await (await fetch(`http://localhost:1234/goosemod.${locale}.js`)).text());
-  // eval(await (await fetch(`https://raw.githubusercontent.com/GooseMod/GooseMod/dist-dev/goosemod.${locale}.js?_<buildtime>`, { cache: 'force-cache' })).text());
+  // eval(await (await fetch(`http://localhost:1234/goosemod.${locale}.js`)).text());
+  eval(await (await fetch(`https://raw.githubusercontent.com/GooseMod/GooseMod/dist-dev/goosemod.${locale}.js?_<buildtime>`, { cache: 'force-cache' })).text());
 };
 
 init();

--- a/building/i18n/translations/en-US.json
+++ b/building/i18n/translations/en-US.json
@@ -9,6 +9,7 @@
     "install": "Install",
     "add": "Add",
     "remove": "Remove",
+    "openLink": "Open Link",
 
     "refresh": "Refresh",
 

--- a/src/ui/settings/home/repos.js
+++ b/src/ui/settings/home/repos.js
@@ -21,6 +21,21 @@ export default async () => {
       return React.createElement('div', {},
         React.createElement(Button, {
           style: {
+            width: '100px',
+
+            position: 'absolute',
+            right: '108px',
+            marginTop: '33px'
+          },
+
+          color: ButtonClasses["colorPrimary"],
+          size: ButtonClasses["sizeSmall"],
+
+          onClick: this.props.buttonOpenLink
+        }, "#terms.openLink#"),
+
+        React.createElement(Button, {
+          style: {
             width: '92px',
             
             position: 'absolute',
@@ -161,6 +176,10 @@ export default async () => {
           repo.enabled = e;
 
           updateAfterChange();
+        },
+
+        buttonOpenLink: () => {
+          window.open(repo.url);
         },
 
         buttonOnClick: async () => {


### PR DESCRIPTION
Add a "Open Link" button next to the "Remove" button in the Repos Modal to allow easy access to the repo's URL.

![image](https://user-images.githubusercontent.com/48562304/181917336-71c72b97-0a45-4097-9dea-a36848f78210.png)
